### PR TITLE
refactor: rename project from next-starter to waitlist

### DIFF
--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,6 +1,6 @@
 ### Issue 😱:
 
-Closes https://github.com/Skolaczk/next-starter/issues
+Closes https://github.com/greencommit/waitlist/issues
 
 ### What has been done ✅:
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -2,7 +2,7 @@
   "home": {
     "signIn": "Sign in",
     "signOut": "Sign out",
-    "subtitle": "A Next.js starter template, packed with features like TypeScript, Tailwind CSS, Next-auth, Eslint, Stripe, testing tools and more. Jumpstart your project with efficiency and style.",
+    "subtitle": "waitlist page for GreenCommit, a platform that connects open-source maintainers and contributors. The page allows users to sign up for early access, view community activity, and validate interest before launch.",
     "getStartedButton": "Get started"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "next-starter",
+  "name": "waitlist",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-starter",
+      "name": "waitlist",
       "version": "0.1.0",
       "dependencies": {
         "@auth/drizzle-adapter": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "next-starter",
+  "name": "waitlist",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/src/__tests__/e2e/home.spec.ts
+++ b/src/__tests__/e2e/home.spec.ts
@@ -3,5 +3,5 @@ import { expect, test } from "@playwright/test";
 test("has title", async ({ page }) => {
   await page.goto("/");
 
-  await expect(page).toHaveTitle(/Next.js Starter/);
+  await expect(page).toHaveTitle(/waitlist/);
 });

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -16,7 +16,7 @@ const HomePage = async () => {
       <header className="w-full border-b">
         <div className="container flex h-16 items-center justify-between">
           <Link href="#" className="font-mono text-lg font-bold">
-            next-starter
+            waitlist
           </Link>
           <div className="flex items-center gap-2">
             <AuthControls session={session} />
@@ -28,7 +28,7 @@ const HomePage = async () => {
           <span className="bg-gradient-to-r from-rose-700 to-pink-600 bg-clip-text text-transparent">
             Next.js
           </span>{" "}
-          starter template
+          waitlist
         </h1>
         <p className="text-muted-foreground max-w-2xl md:text-lg">
           {t("subtitle")}
@@ -38,7 +38,7 @@ const HomePage = async () => {
             <StripeButton />
           ) : (
             <Link
-              href="https://github.com/Skolaczk/next-starter/blob/main/README.md#getting-started"
+              href="https://github.com/greencommit/waitlist/blob/main/README.md#getting-started"
               target="_blank"
               className={buttonVariants({ size: "lg" })}
             >
@@ -46,7 +46,7 @@ const HomePage = async () => {
             </Link>
           )}
           <Link
-            href="https://github.com/Skolaczk/next-starter"
+            href="https://github.com/greencommit/waitlist"
             target="_blank"
             className={buttonVariants({ variant: "outline", size: "lg" })}
           >

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -1,10 +1,16 @@
 import { env } from "@/env.mjs";
 
 export const siteConfig = {
-  title: "Next.js Starter",
+  title: "waitlist",
   description:
-    "A Next.js starter template, packed with features like TypeScript, Tailwind CSS, Next-auth, Eslint, testing tools and more. Jumpstart your project with efficiency and style.",
-  keywords: ["Next.js", "TypeScript", "Tailwind CSS", "Next-auth"],
+    "waitlist page for GreenCommit, a platform that connects open-source maintainers and contributors. The page allows users to sign up for early access, view community activity, and validate interest before launch.",
+  keywords: [
+    "waitlist",
+    "GreenCommit",
+    "open-source",
+    "maintainers",
+    "contributors",
+  ],
   url: env.APP_URL,
   googleSiteVerificationId: env.GOOGLE_SITE_VERIFICATION_ID || "",
 };


### PR DESCRIPTION
Update all references to the project name in package.json, tests, documentation, and UI components to reflect the new project name "waitlist" for GreenCommit platform